### PR TITLE
Make the error message even clearer

### DIFF
--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -52,7 +52,7 @@ module Grape
                                 :desc    => 'Number of results to return per page.',
                                 :values  => {
                                               :value   =>  per_page_values,
-                                              :message => "is invalid. Can only ask for at most #{options[:max_per_page]} records per request."
+                                              :message => "only allows at most #{options[:max_per_page]} records per request."
                                 }
           end
         end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -83,7 +83,7 @@ describe NumbersAPI do
         before { get '/numbers_with_enforced_max_per_page', :count => 100, :per_page => 30 }
 
         it 'should not allow value above the max_per_page_limit' do
-          body = '{"error":"per_page is invalid. Can only ask for at most 25 records per request."}'
+          body = '{"error":"per_page only allows at most 25 records per request."}'
 
           expect(last_response.body).to eq(body)
         end


### PR DESCRIPTION
having the `is invalid` portion of the string can cause a duplicate error message in the JSON error response