### PR TITLE
Allow the api-pagination gem to pass in the proper options to kaminari when doing `paginate_array`

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -12,7 +12,7 @@ module ApiPagination
       when :pagy
         paginate_with_pagy(collection, options)
       when :kaminari
-        paginate_with_kaminari(collection, options, options[:paginate_array_options] || {})
+        paginate_with_kaminari(collection, options)
       when :will_paginate
         paginate_with_will_paginate(collection, options)
       else
@@ -87,7 +87,7 @@ module ApiPagination
       end
     end
 
-    def paginate_with_kaminari(collection, options, paginate_array_options = {})
+    def paginate_with_kaminari(collection, options)
       if Kaminari.config.max_per_page && options[:per_page] > Kaminari.config.max_per_page
         options[:per_page] = Kaminari.config.max_per_page
       elsif options[:per_page] <= 0
@@ -97,11 +97,11 @@ module ApiPagination
       if collection.is_a?(Array) || (options.key?(:paginate_array) && !!options[:paginate_array])
         # These options are needed for kaminari to paginate an array
         # https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/models/array_extension.rb#L70
-        paginate_array_options.merge(
+        paginate_array_options = {
           limit:       options[:per_page],
           offset:      options[:per_page] * (options[:page] - 1),
           total_count: collection.respond_to?(:count) ? collection.count : collection.length
-        )
+        }
         collection = Kaminari.paginate_array(collection, paginate_array_options)
       end
 

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -95,6 +95,13 @@ module ApiPagination
       end
 
       if collection.is_a?(Array) || (options.key?(:paginate_array) && !!options[:paginate_array])
+        # These options are needed for kaminari to paginate an array
+        # https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/models/array_extension.rb#L70
+        paginate_array_options.merge(
+          limit:       options[:per_page],
+          offset:      options[:per_page] * (options[:page] - 1),
+          total_count: collection.respond_to?(:count) ? collection.count : collection.length
+        )
         collection = Kaminari.paginate_array(collection, paginate_array_options)
       end
 

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -96,7 +96,7 @@ module ApiPagination
 
       if collection.is_a?(Array) || (options.key?(:paginate_array) && !!options[:paginate_array])
         # These options are needed for kaminari to paginate an array
-        # https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/models/array_extension.rb#L70
+        # https://github.com/kaminari/kaminari/blob/f90509f398e0fec1713d9c982b7439db5123ed3f/kaminari-core/lib/kaminari/models/array_extension.rb#L70
         paginate_array_options = {
           limit:       options[:per_page],
           offset:      options[:per_page] * (options[:page] - 1),


### PR DESCRIPTION
Currently we have to pass these options in from tracker, which leads to duplicated code having to figure out the `offset`, `total_count` and `limit`. We already have this right in the `api-pagination` code, so just use it here.

Here is the code that is duplicated from having to figure out these options https://github.com/tenjin/tracker/blob/master/app/api/client_api/v2/reports.rb#L35

Now we can just simply do:

`paginate(parray, paginate_array: true)`

Note that this is a by-product of having our reporting data _look_ like an `Array`, but it's not.